### PR TITLE
feat(payments): provider payouts onboarding via Stripe Connect Express

### DIFF
--- a/app/api/stripe/connect/link/route.ts
+++ b/app/api/stripe/connect/link/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import Stripe from "stripe";
+import { db } from "@/db/db";
+import { providersTable } from "@/db/schema/providers-schema";
+import { eq } from "drizzle-orm";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: "2024-06-20",
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const { userId } = auth();
+    
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const { providerId } = body;
+
+    if (!providerId) {
+      return NextResponse.json({ error: "Provider ID required" }, { status: 400 });
+    }
+
+    // Fetch provider from database
+    const [provider] = await db
+      .select()
+      .from(providersTable)
+      .where(eq(providersTable.id, providerId))
+      .limit(1);
+
+    if (!provider) {
+      return NextResponse.json({ error: "Provider not found" }, { status: 404 });
+    }
+
+    // Verify the current user owns this provider profile
+    if (provider.userId !== userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+    }
+
+    let stripeAccountId = provider.stripeConnectAccountId;
+
+    // Create Stripe Connect Express account if doesn't exist
+    if (!stripeAccountId) {
+      const account = await stripe.accounts.create({
+        type: "express",
+        country: "CA", // Canada as specified
+        capabilities: {
+          card_payments: { requested: true },
+          transfers: { requested: true },
+        },
+        business_type: "individual", // Default to individual, can be changed during onboarding
+      });
+
+      stripeAccountId = account.id;
+
+      // Save the Stripe account ID to the provider
+      await db
+        .update(providersTable)
+        .set({ 
+          stripeConnectAccountId: stripeAccountId,
+          updatedAt: new Date(),
+        })
+        .where(eq(providersTable.id, providerId));
+    }
+
+    // Create account link for onboarding
+    const accountLink = await stripe.accountLinks.create({
+      account: stripeAccountId,
+      refresh_url: `${process.env.NEXT_PUBLIC_APP_URL || process.env.APP_BASE_URL || "http://localhost:3000"}/dashboard/payouts?refresh=1`,
+      return_url: `${process.env.NEXT_PUBLIC_APP_URL || process.env.APP_BASE_URL || "http://localhost:3000"}/dashboard/payouts?return=1`,
+      type: "account_onboarding",
+    });
+
+    return NextResponse.json({ url: accountLink.url });
+  } catch (error) {
+    console.error("Error creating Stripe Connect link:", error);
+    
+    if (error instanceof Stripe.errors.StripeError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.statusCode || 400 }
+      );
+    }
+    
+    return NextResponse.json(
+      { error: "Failed to create onboarding link" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -12,6 +12,9 @@ import { revalidatePath } from "next/cache";
 import CancellationPopup from "@/components/cancellation-popup";
 import WelcomeMessagePopup from "@/components/welcome-message-popup";
 import PaymentSuccessPopup from "@/components/payment-success-popup";
+import { providersTable } from "@/db/schema/providers-schema";
+import { db } from "@/db/db";
+import { eq } from "drizzle-orm";
 
 /**
  * Check if a free user with an expired billing cycle needs their credits downgraded
@@ -87,6 +90,13 @@ export default async function DashboardLayout({ children }: { children: ReactNod
   const user = await currentUser();
   const userEmail = user?.emailAddresses?.[0]?.emailAddress || "";
   
+  // Check if user is a provider
+  const [provider] = await db
+    .select()
+    .from(providersTable)
+    .where(eq(providersTable.userId, userId))
+    .limit(1);
+  
   // Log profile details for debugging
   console.log('Dashboard profile:', {
     userId: profile.userId,
@@ -111,7 +121,8 @@ export default async function DashboardLayout({ children }: { children: ReactNod
       {/* Sidebar component with profile data and user email */}
       <Sidebar 
         profile={profile} 
-        userEmail={userEmail} 
+        userEmail={userEmail}
+        isProvider={!!provider}
       />
       
       {/* Main content area */}

--- a/app/dashboard/payouts/page.tsx
+++ b/app/dashboard/payouts/page.tsx
@@ -1,0 +1,41 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { db } from "@/db/db";
+import { providersTable } from "@/db/schema/providers-schema";
+import { eq } from "drizzle-orm";
+import PayoutsClient from "./payouts-client";
+
+export default async function PayoutsPage() {
+  const { userId } = auth();
+
+  if (!userId) {
+    redirect("/login");
+  }
+
+  // Fetch provider profile for current user
+  const [provider] = await db
+    .select()
+    .from(providersTable)
+    .where(eq(providersTable.userId, userId))
+    .limit(1);
+
+  if (!provider) {
+    // User is not a provider, redirect to dashboard
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">Payout Settings</h1>
+        <p className="text-gray-600">
+          Manage your payout account and view your earnings
+        </p>
+      </div>
+
+      <PayoutsClient 
+        provider={provider}
+      />
+    </div>
+  );
+}

--- a/app/dashboard/payouts/payouts-client.tsx
+++ b/app/dashboard/payouts/payouts-client.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Provider } from "@/db/schema/providers-schema";
+import { CheckCircle2, AlertCircle, ExternalLink, Loader2, DollarSign, CreditCard } from "lucide-react";
+
+interface PayoutsClientProps {
+  provider: Provider;
+}
+
+export default function PayoutsClient({ provider }: PayoutsClientProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  // Check for return parameters from Stripe
+  const isReturn = searchParams.get("return") === "1";
+  const isRefresh = searchParams.get("refresh") === "1";
+
+  useEffect(() => {
+    // Clear URL parameters after reading them
+    if (isReturn || isRefresh) {
+      router.replace("/dashboard/payouts");
+    }
+  }, [isReturn, isRefresh, router]);
+
+  const handleConnectPayouts = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      const response = await fetch("/api/stripe/connect/link", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          providerId: provider.id,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to create onboarding link");
+      }
+
+      const { url } = await response.json();
+
+      // Redirect to Stripe Connect onboarding
+      window.location.href = url;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+      setIsLoading(false);
+    }
+  };
+
+  const isConnected = !!provider.stripeConnectAccountId;
+  const isOnboardingComplete = provider.stripeOnboardingComplete;
+
+  return (
+    <div className="space-y-6">
+      {/* Success message when returning from Stripe */}
+      {isReturn && isConnected && (
+        <Alert className="border-green-200 bg-green-50">
+          <CheckCircle2 className="h-4 w-4 text-green-600" />
+          <AlertDescription className="text-green-800">
+            Successfully connected your Stripe account! You may need to complete additional verification steps.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Refresh message */}
+      {isRefresh && (
+        <Alert className="border-blue-200 bg-blue-50">
+          <AlertCircle className="h-4 w-4 text-blue-600" />
+          <AlertDescription className="text-blue-800">
+            Your onboarding session expired. Click &ldquo;Connect Payouts&rdquo; to continue.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Error message */}
+      {error && (
+        <Alert className="border-red-200 bg-red-50">
+          <AlertCircle className="h-4 w-4 text-red-600" />
+          <AlertDescription className="text-red-800">{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Payout Account Status Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <CreditCard className="h-5 w-5" />
+            Payout Account Status
+          </CardTitle>
+          <CardDescription>
+            Connect your Stripe account to receive payouts from bookings
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between py-3 px-4 bg-gray-50 rounded-lg">
+            <div className="flex items-center gap-3">
+              <div
+                className={`h-3 w-3 rounded-full ${
+                  isConnected ? "bg-green-500" : "bg-gray-300"
+                }`}
+              />
+              <div>
+                <p className="font-medium text-sm">
+                  {isConnected ? "Account Connected" : "Not Connected"}
+                </p>
+                {isConnected && (
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    Account ID: {provider.stripeConnectAccountId}
+                  </p>
+                )}
+              </div>
+            </div>
+            
+            {!isOnboardingComplete && isConnected && (
+              <span className="text-xs bg-yellow-100 text-yellow-800 px-2 py-1 rounded-full">
+                Verification Required
+              </span>
+            )}
+          </div>
+
+          {!isConnected ? (
+            <div className="space-y-4">
+              <p className="text-sm text-gray-600">
+                To receive payouts from customer bookings, you need to connect a Stripe account. 
+                This allows us to securely transfer your earnings directly to your bank account.
+              </p>
+              
+              <Button
+                onClick={handleConnectPayouts}
+                disabled={isLoading}
+                className="w-full sm:w-auto"
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Connecting...
+                  </>
+                ) : (
+                  <>
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    Connect Payouts
+                  </>
+                )}
+              </Button>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {isOnboardingComplete ? (
+                <p className="text-sm text-green-600">
+                  ✓ Your payout account is fully set up and ready to receive payments.
+                </p>
+              ) : (
+                <>
+                  <p className="text-sm text-gray-600">
+                    Your account is connected but may require additional verification. 
+                    Click below to complete the setup process.
+                  </p>
+                  <Button
+                    onClick={handleConnectPayouts}
+                    disabled={isLoading}
+                    variant="outline"
+                    className="w-full sm:w-auto"
+                  >
+                    {isLoading ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        Loading...
+                      </>
+                    ) : (
+                      <>
+                        <ExternalLink className="mr-2 h-4 w-4" />
+                        Complete Setup
+                      </>
+                    )}
+                  </Button>
+                </>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Commission Info Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <DollarSign className="h-5 w-5" />
+            Platform Commission
+          </CardTitle>
+          <CardDescription>
+            Your earnings after platform fees
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            <div className="flex justify-between items-center py-2">
+              <span className="text-sm text-gray-600">Platform Fee</span>
+              <span className="font-medium">{(Number(provider.commissionRate) * 100).toFixed(0)}%</span>
+            </div>
+            <div className="flex justify-between items-center py-2">
+              <span className="text-sm text-gray-600">Your Earnings</span>
+              <span className="font-medium">{(100 - Number(provider.commissionRate) * 100).toFixed(0)}%</span>
+            </div>
+            <div className="pt-2 border-t">
+              <p className="text-xs text-gray-500">
+                For every $100 booking, you receive ${(100 * (1 - Number(provider.commissionRate))).toFixed(2)} after fees.
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Placeholder for future features */}
+      {isConnected && isOnboardingComplete && (
+        <Card className="border-dashed">
+          <CardHeader>
+            <CardTitle className="text-gray-400">Coming Soon</CardTitle>
+            <CardDescription className="text-gray-400">
+              View your earnings history, pending payouts, and transaction details
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -5,7 +5,7 @@
  */
 "use client";
 
-import { Home, Settings, Database, Target, Users, Sparkles, CreditCard } from "lucide-react";
+import { Home, Settings, Database, Target, Users, Sparkles, CreditCard, DollarSign } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { UserButton } from "@clerk/nextjs";
@@ -19,9 +19,10 @@ import { useState, useEffect, useCallback } from "react";
 interface SidebarProps {
   profile: SelectProfile | null;
   userEmail?: string;
+  isProvider?: boolean;
 }
 
-export default function Sidebar({ profile, userEmail }: SidebarProps) {
+export default function Sidebar({ profile, userEmail, isProvider = false }: SidebarProps) {
   const pathname = usePathname();
   const router = useRouter();
   const [showUpgradePopup, setShowUpgradePopup] = useState(false);
@@ -44,6 +45,7 @@ export default function Sidebar({ profile, userEmail }: SidebarProps) {
     { href: "/dashboard/data-source", icon: <Database size={16} />, label: "Data source" },
     { href: "/dashboard/targets", icon: <Target size={16} />, label: "Targets" },
     { href: "/dashboard/members", icon: <Users size={16} />, label: "Members" },
+    ...(isProvider ? [{ href: "/dashboard/payouts", icon: <DollarSign size={16} />, label: "Payouts" }] : []),
   ];
 
   // Handle navigation item click


### PR DESCRIPTION
- Added stripe_account_id field to providers schema (already existed)
- Created POST /api/stripe/connect/link route for onboarding
  - Creates Express accounts for Canadian providers
  - Generates account links for onboarding flow
  - Stores stripe_account_id in database
- Added /dashboard/payouts page for providers
  - Shows connection status and onboarding button
  - Displays commission rates and earnings info
  - Handles return/refresh from Stripe onboarding
- Updated sidebar to show Payouts link for providers only
- Modified dashboard layout to detect provider status

Providers can now connect their Stripe accounts to receive payouts from bookings.